### PR TITLE
Deploy sauce to Google App Engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     executor:
       name: node/default
-      tag: "12"
+      tag: "12.20"
     steps:
       - checkout
       - node/install-packages
@@ -29,7 +29,7 @@ workflows:
     jobs:
       - lint
       - node/test:
-          version: "12"
+          version: "12.20"
       - deploy:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     executor:
       name: node/default
-      tag: 12
+      tag: "12"
     steps:
       - checkout
       - node/install-packages
@@ -29,7 +29,7 @@ workflows:
     jobs:
       - lint
       - node/test:
-          version: 12
+          version: "12"
       - deploy:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     executor:
       name: node/default
-      tag: "14.15.1"
+      tag: 12
     steps:
       - checkout
       - node/install-packages
@@ -29,7 +29,7 @@ workflows:
     jobs:
       - lint
       - node/test:
-          version: 14.15.1
+          version: 12
       - deploy:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 orbs:
   node: circleci/node@4.1.0
+  gcp-cli: circleci/gcp-cli@2.1.0
 
 version: 2.1
 
@@ -13,10 +14,23 @@ jobs:
       - node/install-packages
       - run:
           command: npm run lint
+  deploy:
+    executor:
+      name: gcp-cli/google
+    steps:
+      - checkout
+      - gcp-cli/install
+      - gcp-cli/initialize
+      - run:
+          command: gcloud app deploy app.yaml
 
 workflows:
-  app-tests:
+  test-and-deploy:
     jobs:
       - lint
       - node/test:
           version: 14.15.1
+      - deploy:
+          requires:
+            - lint
+            - node/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,7 @@ workflows:
           requires:
             - lint
             - node/test
+          filters:
+            branches:
+              only:
+                - main

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,6 @@
+.gcloudignore
+.git
+.gitignore
+node_modules/
+bin/
+scripts/

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   web:
-    image: node:14.15.1
+    image: node:12
     volumes:
       - .:/sauce
     restart: "no"
@@ -16,7 +16,7 @@ services:
           - sauce
 
   node:
-    image: node:14.15.1
+    image: node:12
     volumes:
       - .:/sauce
     restart: "no"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "repository": "github:wkndprgmr/sauce",
   "license": "AGPL-3.0",
   "scripts": {
+    "start": "node src/main.js",
     "fmt": "prettier --write .",
     "lint": "./scripts/lint.js",
     "test": "ava"

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,8 @@
 const express = require("express");
 
 const app = express();
-app.get("/", (req, res) => res.send());
+app.get("/", (req, res) => {
+  res.status(200).send("feeling saucy").end();
+});
 
 module.exports = app;

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ const express = require("express");
 
 const app = express();
 app.get("/", (req, res) => {
-  res.status(200).send("feeling saucy").end();
+  res.status(200).send("feeling saucy!").end();
 });
 
 module.exports = app;

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,6 @@
 const app = require("./app");
 
-app.listen(80);
+const PORT = process.env.PORT || 80;
+app.listen(PORT, () => {
+  console.log(`sauce listening on port ${PORT}`);
+});


### PR DESCRIPTION
Right now changes will be deployed to https://sauce-staging.wkndprgmr.dev while I am still learning Google App Engine.

I learned some good things by doing this:

- Setting up access/permissions for my custom deployer role in GCP
- Configuring CircleCI env vars with the GCP orb

Some things to consider in the future:

- Using CircleCI contexts for different environments (staging vs prod)
- Deploying different "versions" of the app automatically for testing, similar to how heroku pr-builds work